### PR TITLE
Resolve group dependencies

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,7 +18,6 @@
   Bloom does not support group_depend so entries below duplicate the group rosidl_typesupport_cpp_packages.
   This ensures that binary packages have support for all of these rmw impl. enabled.
   -->
-  <build_depend>rosidl_typesupport_connext_cpp</build_depend>
   <build_depend>rosidl_typesupport_introspection_cpp</build_depend>
   <!-- end of group rosidl_typesupport_cpp_packages for bloom -->
 

--- a/rpm/template.spec.em
+++ b/rpm/template.spec.em
@@ -24,6 +24,10 @@ Source0:        %{name}-%{version}.tar.gz
 @[for p in Supplements]Supplements:    @p@\n@[end for]@
 %endif@\n@[end if]@
 
+%if 0%{?with_weak_deps}
+Suggests:       ros-rolling-rosidl-typesupport-fastrtps-cpp
+%endif
+
 %description
 @(Description)
 


### PR DESCRIPTION
Debian counterpart: https://github.com/ros2-gbp/rosidl_typesupport-release/blob/patches/debian/eloquent/rosidl_typesupport_cpp/0001-Add-Suggests-for-vendor-typesupport-packages.patch

Note that this won't have any affect on CentOS 7, since weak dependencies aren't supported there.

Also drop the unavailable RMWs from the package.xml.

**NOTE**: If this PR is squash-merged, be sure to drop the PR number from the end of the commit message, or every time this patch is re-applied by Bloom, it will be back-linked from this PR.