### PR TITLE
Update patches for RHEL 8

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -19,7 +19,6 @@
   Bloom does not support group_depend so entries below duplicate the group rosidl_typesupport_c_packages.
   This ensures that binary packages have support for all of these rmw impl. enabled.
   -->
-  <build_depend>rosidl_typesupport_connext_c</build_depend>
   <build_depend>rosidl_typesupport_introspection_c</build_depend>
   <!-- end of group rosidl_typesupport_c_packages for bloom -->
 

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
   Bloom does not support group_depend so entries below duplicate the group rosidl_typesupport_c_packages.
   This ensures that binary packages have support for all of these rmw impl. enabled.
   -->
+  <build_depend>rosidl_typesupport_connext_c</build_depend>
   <build_depend>rosidl_typesupport_introspection_c</build_depend>
   <!-- end of group rosidl_typesupport_c_packages for bloom -->
 

--- a/rpm/template.spec.em
+++ b/rpm/template.spec.em
@@ -1,3 +1,7 @@
+@{
+# FastRTPS nor Connext are available for RHEL - ignore any deps related to them
+BuildDepends = [d for d in BuildDepends if not any(x for x in ['connext', 'fastrtps'] if x in d)]
+}@
 %bcond_without tests
 %bcond_without weak_deps
 

--- a/rpm/template.spec.em
+++ b/rpm/template.spec.em
@@ -24,10 +24,6 @@ Source0:        %{name}-%{version}.tar.gz
 @[for p in Supplements]Supplements:    @p@\n@[end for]@
 %endif@\n@[end if]@
 
-%if 0%{?with_weak_deps}
-Suggests:       ros-rolling-rosidl-typesupport-fastrtps-c
-%endif
-
 %description
 @(Description)
 


### PR DESCRIPTION
This change should be **fast-forward** merged after review.

Most notably, this change drops the weak dependency on Fast-RTPS. It also takes a different approach to dropping the build dependency on Connext that is less likely to be accidentally dropped.