### PR TITLE
rosidl_typesupport_cpp: Drop retired connext package from suggestions.

### DIFF
--- a/debian/control.em
+++ b/debian/control.em
@@ -11,5 +11,5 @@ Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, @(', '.join(Depends))
 @[if Conflicts]Conflicts: @(', '.join(Conflicts))@\n@[end if]@
 @[if Replaces]Replaces: @(', '.join(Replaces))@\n@[end if]@
-Suggests: ros-@Rosdistro-rosidl-typesupport-fastrtps-cpp
+Suggests: ros-@(Rosdistro)-rosidl-typesupport-fastrtps-cpp
 Description: @(Description)

--- a/debian/control.em
+++ b/debian/control.em
@@ -11,5 +11,5 @@ Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, @(', '.join(Depends))
 @[if Conflicts]Conflicts: @(', '.join(Conflicts))@\n@[end if]@
 @[if Replaces]Replaces: @(', '.join(Replaces))@\n@[end if]@
-Suggests: ros-@Rosdistro-rosidl-typesupport-connext-cpp, ros-@Rosdistro-rosidl-typesupport-fastrtps-cpp
+Suggests: ros-@Rosdistro-rosidl-typesupport-fastrtps-cpp
 Description: @(Description)

--- a/debian/control.em
+++ b/debian/control.em
@@ -11,5 +11,5 @@ Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, @(', '.join(Depends))
 @[if Conflicts]Conflicts: @(', '.join(Conflicts))@\n@[end if]@
 @[if Replaces]Replaces: @(', '.join(Replaces))@\n@[end if]@
-Suggests: ros-rolling-rosidl-typesupport-connext-cpp, ros-rolling-rosidl-typesupport-fastrtps-cpp
+Suggests: ros-@Rosdistro-rosidl-typesupport-connext-cpp, ros-@Rosdistro-rosidl-typesupport-fastrtps-cpp
 Description: @(Description)


### PR DESCRIPTION
This means that blooming this will require bloom 0.10.1 but since
Rolling and Galactic require bloom 0.10.3 or newer anyway that should
not be an issue.